### PR TITLE
[Feature] User errors vs System errors

### DIFF
--- a/cli/apply.go
+++ b/cli/apply.go
@@ -63,12 +63,12 @@ func ApplyGetOpts(cmd *cobra.Command, args []string) (opts *ApplyOpts, warns []s
 	}
 	if pkgURLFlag := cmd.Flags().Lookup("package-file-url"); pkgURLFlag != nil {
 		if pkgURL != "" {
-			return nil, warns, fmt.Errorf("flags 'package-file' and 'package-file-url' cannot be set at same time. If the file is local and working directly with KubeKit, use 'package-file'. If the file is remote use 'package-file-url'. Use 'package-file-url' if working with KubeKit as a client")
+			return nil, warns, UserErrorf("flags 'package-file' and 'package-file-url' cannot be set at same time. If the file is local and working directly with KubeKit, use 'package-file'. If the file is remote use 'package-file-url'. Use 'package-file-url' if working with KubeKit as a client")
 		}
 		pkgURL := pkgURLFlag.Value.String()
 		if pkgURL != "" {
 			if _, err = url.Parse(pkgURL); err != nil {
-				return nil, warns, fmt.Errorf("the value of 'package-file-url' (%q) is not a valid URL. %s", pkgURL, err)
+				return nil, warns, UserErrorf("the value of 'package-file-url' (%q) is not a valid URL. %s", pkgURL, err)
 			}
 		}
 	}

--- a/cli/get_env.go
+++ b/cli/get_env.go
@@ -36,7 +36,7 @@ func GetEnvGetOpts(cmd *cobra.Command, args []string) (opts *GetEnvOpts, warns [
 	}
 
 	if len(clusterName) == 0 && !unset {
-		return nil, warns, fmt.Errorf("cluster name is required unless --unset or -u is used")
+		return nil, warns, UserErrorf("cluster name is required unless --unset or -u is used")
 	}
 
 	shell := DefaultShell

--- a/cli/get_nodes.go
+++ b/cli/get_nodes.go
@@ -47,18 +47,18 @@ func GetNodesGetOpts(cmd *cobra.Command, args []string) (opts *GetNodesOpts, war
 	nodesStr := cmd.Flags().Lookup("nodes").Value.String()
 	nodes, err := StringToArray(nodesStr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse the list of nodes")
+		return nil, nil, UserErrorf("failed to parse the list of nodes")
 	}
 
 	// Pools:
 	poolsStr := cmd.Flags().Lookup("pools").Value.String()
 	pools, err := StringToArray(poolsStr)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to parse the list of pools")
+		return nil, nil, UserErrorf("failed to parse the list of pools")
 	}
 
 	if len(nodes) != 0 && len(pools) != 0 {
-		return nil, nil, fmt.Errorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
+		return nil, nil, UserErrorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
 	}
 
 	return &GetNodesOpts{
@@ -88,7 +88,7 @@ func (cni ClusterNodeInfo) Sprintf(format string, pp bool) (string, error) {
 	case "quiet":
 		return cni.IPs(), nil
 	default:
-		return "", fmt.Errorf("unknown format %q", format)
+		return "", UserErrorf("unknown format %q", format)
 	}
 }
 

--- a/cli/init.go
+++ b/cli/init.go
@@ -23,7 +23,7 @@ type InitOpts struct {
 // GetMultipleClustersName retrive from the CLI (cobra) arguments one or more clusters name
 func GetMultipleClustersName(cmd *cobra.Command, args []string) ([]string, error) {
 	if len(args) == 0 {
-		return nil, fmt.Errorf("requires a cluster name")
+		return nil, UserErrorf("requires a cluster name")
 	}
 	return args, nil
 }
@@ -31,13 +31,13 @@ func GetMultipleClustersName(cmd *cobra.Command, args []string) ([]string, error
 // GetOneClusterName retrive from the CLI (cobra) arguments one cluster name which could be valid or not
 func GetOneClusterName(cmd *cobra.Command, args []string, validate bool) (clusterName string, err error) {
 	if len(args) == 0 {
-		return "", fmt.Errorf("requires a cluster name")
+		return "", UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return "", fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return "", UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	if len(args[0]) == 0 {
-		return "", fmt.Errorf("cluster name cannot be empty")
+		return "", UserErrorf("cluster name cannot be empty")
 	}
 	if validate {
 		return kluster.ValidClusterName(args[0])
@@ -68,7 +68,7 @@ func InitGetOpts(cmd *cobra.Command, args []string) (opts *InitOpts, warns []str
 	// Validate platform (required unless it's an update)
 	platform := cmd.Flags().Lookup("platform").Value.String()
 	if len(platform) == 0 && !update {
-		return nil, warns, fmt.Errorf("platform is required")
+		return nil, warns, UserErrorf("platform is required")
 	}
 	platform = strings.ToLower(platform)
 

--- a/cli/kubekit/apply.go
+++ b/cli/kubekit/apply.go
@@ -114,14 +114,14 @@ func addApplyCmd() {
 
 func applyCertificatesRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	cluster, err := loadCluster(clusterName)
@@ -136,14 +136,14 @@ func applyCertificatesRun(cmd *cobra.Command, args []string) error {
 
 func applyClusterRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	// the cluster config file must exists. This command should be executed after 'init' or will fail
@@ -338,14 +338,14 @@ func configure(cluster *kluster.Kluster) error {
 
 func actionPackageRun(cmd *cobra.Command, args []string, doExec bool) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	pkgFilename := cmd.Flags().Lookup("package-file").Value.String()

--- a/cli/kubekit/cmd.go
+++ b/cli/kubekit/cmd.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/liferaft/kubekit/cli"
 	"github.com/liferaft/kubekit/pkg/kluster"
 	"github.com/spf13/cobra"
 )
@@ -27,7 +28,9 @@ func Execute() {
 			config.UI.Log.Error(err.Error())
 		}
 		fmt.Fprintf(os.Stderr, "\n\x1B[91;1m[ERROR]\x1B[0m %s\n", err)
-		c.Printf("\n%s\n", c.UsageString())
+		if _, ok := err.(cli.UserError); ok {
+			c.Printf("\n%s\n", c.UsageString())
+		}
 		os.Exit(-1)
 	}
 }

--- a/cli/kubekit/config.go
+++ b/cli/kubekit/config.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/johandry/log"
 	"github.com/kraken/ui"
+	"github.com/liferaft/kubekit/cli"
 	homedir "github.com/mitchellh/go-homedir"
 	toml "github.com/pelletier/go-toml"
 	"github.com/spf13/cobra"
@@ -203,7 +204,7 @@ func (c *Config) Stringf(format string, pp bool) (string, error) {
 	case "text", "txt":
 		return c.Text(pp)
 	default:
-		return "", fmt.Errorf("unknown format %s", format)
+		return "", cli.UserErrorf("unknown format %s", format)
 	}
 }
 

--- a/cli/kubekit/copy.go
+++ b/cli/kubekit/copy.go
@@ -188,33 +188,33 @@ func addCopyCmd() {
 
 func copyClusterConfigRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	newClusterName := cmd.Flags().Lookup("to").Value.String()
 	if len(newClusterName) == 0 && !doExportCC {
-		return fmt.Errorf("new cluster name not found. Use the '--to' flag to set the new name")
+		return cli.UserErrorf("new cluster name not found. Use the '--to' flag to set the new name")
 	}
 	if len(newClusterName) != 0 && doExportCC {
-		return fmt.Errorf("cannot export the cluster config with a new name. Do not use '--to' with '--export'")
+		return cli.UserErrorf("cannot export the cluster config with a new name. Do not use '--to' with '--export'")
 	}
 
 	newPlatform := cmd.Flags().Lookup("platform").Value.String()
 	if len(newPlatform) != 0 && doExportCC {
-		return fmt.Errorf("cannot export the cluster to a new platform. Do not use the `--export` flag with `--platform` flag")
+		return cli.UserErrorf("cannot export the cluster to a new platform. Do not use the `--export` flag with `--platform` flag")
 	}
 	path := cmd.Flags().Lookup("path").Value.String()
 	format := cmd.Flags().Lookup("format").Value.String()
 	templateName := cmd.Flags().Lookup("template").Value.String()
 	if len(templateName) != 0 && doExportCC {
-		return fmt.Errorf("cannot export the cluster using a template. Do not use the `--export` flag with `--template` flag")
+		return cli.UserErrorf("cannot export the cluster using a template. Do not use the `--export` flag with `--template` flag")
 	}
 
 	if len(newClusterName) == 0 && doExportCC {
@@ -245,34 +245,34 @@ func copyClusterConfigRun(cmd *cobra.Command, args []string) error {
 
 func copyFilesRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	from := cmd.Flags().Lookup("from").Value.String()
 	to := cmd.Flags().Lookup("to").Value.String()
 	check := from[0:1] + to[0:1]
 	if check == "::" || !strings.Contains(check, ":") {
-		return fmt.Errorf("target and source location has to be local and the other remote. Remote locations begins with ':'")
+		return cli.UserErrorf("target and source location has to be local and the other remote. Remote locations begins with ':'")
 	}
 	nodesStr := cmd.Flags().Lookup("nodes").Value.String()
 	nodes, err := cli.StringToArray(nodesStr)
 	if err != nil {
-		return fmt.Errorf("failed to parse the list of nodes")
+		return cli.UserErrorf("failed to parse the list of nodes")
 	}
 	poolsStr := cmd.Flags().Lookup("pools").Value.String()
 	pools, err := cli.StringToArray(poolsStr)
 	if err != nil {
-		return fmt.Errorf("failed to parse the list of pools")
+		return cli.UserErrorf("failed to parse the list of pools")
 	}
 	if len(nodes) != 0 && len(pools) != 0 {
-		return fmt.Errorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
+		return cli.UserErrorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
 	}
 	owner := cmd.Flags().Lookup("owner").Value.String()
 	group := cmd.Flags().Lookup("group").Value.String()
@@ -313,19 +313,19 @@ func copyPackageRun(cmd *cobra.Command, args []string) error {
 
 func copyClusterConfig(sourceClusterName, newClusterName, platform, path, format string, variables map[string]string, templateName string, doExport, doZip bool) (*kluster.Kluster, error) {
 	if len(newClusterName) == 0 {
-		return nil, fmt.Errorf("the new cluster name cannot be empty")
+		return nil, cli.UserErrorf("the new cluster name cannot be empty")
 	}
 	if len(path) == 0 && !kluster.Unique(newClusterName, config.ClustersDir()) {
-		return nil, fmt.Errorf("cluster name %q already exists. List all the names with the 'get clusters' command and select a unique name", newClusterName)
+		return nil, cli.UserErrorf("cluster name %q already exists. List all the names with the 'get clusters' command and select a unique name", newClusterName)
 	}
 
 	klusterFile := kluster.Path(sourceClusterName, config.ClustersDir())
 	if len(klusterFile) == 0 {
-		return nil, fmt.Errorf("failed to find the source cluster named %q", sourceClusterName)
+		return nil, cli.UserErrorf("failed to find the source cluster named %q", sourceClusterName)
 	}
 	sourceCluster, err := kluster.LoadSummary(klusterFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to load the kluster config file %s. %s", klusterFile, err)
+		return nil, cli.UserErrorf("failed to load the kluster config file %s. %s", klusterFile, err)
 	}
 
 	config.UI.Log.Debugf("copying cluster %q to %q", sourceClusterName, newClusterName)
@@ -335,7 +335,7 @@ func copyClusterConfig(sourceClusterName, newClusterName, platform, path, format
 		path = defaultClustersPath
 	} else {
 		if _, err := os.Stat(path); os.IsNotExist(err) {
-			return nil, fmt.Errorf("path %q does not exists", path)
+			return nil, cli.UserErrorf("path %q does not exists", path)
 		}
 	}
 

--- a/cli/kubekit/describe.go
+++ b/cli/kubekit/describe.go
@@ -3,6 +3,7 @@ package kubekit
 import (
 	"fmt"
 
+	"github.com/liferaft/kubekit/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -67,7 +68,7 @@ func addDescribeCmd() {
 
 func describeClusterRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	clustersName := args
 	output := cmd.Flags().Lookup("output").Value.String()
@@ -77,11 +78,11 @@ func describeClusterRun(cmd *cobra.Command, args []string) error {
 	switch output {
 	case "json", "yaml", "toml":
 	default:
-		return fmt.Errorf("unknown or unsupported format %q", output)
+		return cli.UserErrorf("unknown or unsupported format %q", output)
 	}
 
 	if len(output) != 0 && len(format) != 0 {
-		return fmt.Errorf("format template output (--format) cannot be used with any form of output (--output | -o %s), use only one", output)
+		return cli.UserErrorf("format template output (--format) cannot be used with any form of output (--output | -o %s), use only one", output)
 	}
 
 	// DEBUG:
@@ -96,20 +97,20 @@ func describeClusterRun(cmd *cobra.Command, args []string) error {
 
 func describeNodesRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a node hostname or IP address")
+		return cli.UserErrorf("requires a node hostname or IP address")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 node, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 node, received %d. %v", len(args), args)
 	}
 	nodeName := args[0]
 	if len(nodeName) == 0 {
-		return fmt.Errorf("node hostname or IP cannot be empty")
+		return cli.UserErrorf("node hostname or IP cannot be empty")
 	}
 
 	// TODO: Should we remove this and search the node in every cluster?
 	clusterName := cmd.Flags().Lookup("cluster").Value.String()
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name is required")
+		return cli.UserErrorf("cluster name is required")
 	}
 
 	output := cmd.Flags().Lookup("output").Value.String()

--- a/cli/kubekit/edit.go
+++ b/cli/kubekit/edit.go
@@ -82,7 +82,7 @@ func editClusters(editor string, readOnly bool, clustersName ...string) error {
 		return err
 	}
 	if len(klusterList) == 0 || klusterList == nil {
-		return fmt.Errorf("cluster configuration file for %v were not found", clustersName)
+		return fmt.Errorf("cluster configuration file for %v was not found", clustersName)
 	}
 
 	type editError struct {

--- a/cli/kubekit/edit.go
+++ b/cli/kubekit/edit.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/liferaft/kubekit/cli"
 	"github.com/liferaft/kubekit/pkg/kluster"
 	"github.com/spf13/cobra"
 )
@@ -47,7 +48,7 @@ func addEditCmd() {
 
 func editClustersConfigRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	clustersName := args
 
@@ -73,7 +74,7 @@ func editClustersConfigRun(cmd *cobra.Command, args []string) error {
 
 func editClusters(editor string, readOnly bool, clustersName ...string) error {
 	if _, err := os.Stat(editor); os.IsNotExist(err) {
-		return fmt.Errorf("not found editor %q", editor)
+		return cli.UserErrorf("not found editor %q", editor)
 	}
 
 	klusterList, err := kluster.List(config.ClustersDir(), clustersName...)

--- a/cli/kubekit/exec.go
+++ b/cli/kubekit/exec.go
@@ -72,35 +72,35 @@ func addExecCmd() {
 
 func execClusterRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	command := cmd.Flags().Lookup("cmd").Value.String()
 	script := cmd.Flags().Lookup("file").Value.String()
 
 	if len(command) != 0 && len(script) != 0 {
-		return fmt.Errorf("'cmd' and 'file' flags are mutually exclusive, use --cmd or --file but not both in the same command")
+		return cli.UserErrorf("'cmd' and 'file' flags are mutually exclusive, use --cmd or --file but not both in the same command")
 	}
 
 	nodesStr := cmd.Flags().Lookup("nodes").Value.String()
 	nodes, err := cli.StringToArray(nodesStr)
 	if err != nil {
-		return fmt.Errorf("failed to parse the list of nodes")
+		return cli.UserErrorf("failed to parse the list of nodes")
 	}
 	poolsStr := cmd.Flags().Lookup("pools").Value.String()
 	pools, err := cli.StringToArray(poolsStr)
 	if err != nil {
-		return fmt.Errorf("failed to parse the list of pools")
+		return cli.UserErrorf("failed to parse the list of pools")
 	}
 	if len(nodes) != 0 && len(pools) != 0 {
-		return fmt.Errorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
+		return cli.UserErrorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
 	}
 
 	output := cmd.Flags().Lookup("output").Value.String()
@@ -142,14 +142,14 @@ func execClusterRun(cmd *cobra.Command, args []string) error {
 
 func execPackageRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	cluster, err := loadCluster(clusterName)

--- a/cli/kubekit/get.go
+++ b/cli/kubekit/get.go
@@ -122,13 +122,13 @@ func getClustersRun(cmd *cobra.Command, args []string) error {
 
 	if config.Quiet {
 		if len(output) != 0 {
-			return fmt.Errorf("quiet mode cannot be used with any form of output, use only one")
+			return cli.UserErrorf("quiet mode cannot be used with any form of output, use only one")
 		}
 		output = "quiet"
 	}
 
 	if len(output) != 0 && len(format) != 0 {
-		return fmt.Errorf("format template output (--format) cannot be used with any form of output (--output | -o %s), use only one", output)
+		return cli.UserErrorf("format template output (--format) cannot be used with any form of output (--output | -o %s), use only one", output)
 	}
 
 	filter, warns, err := cli.GetFilters(cmd)
@@ -164,14 +164,14 @@ func getNodesRun(cmd *cobra.Command, args []string) error {
 
 	if config.Quiet {
 		if len(opts.Output) != 0 {
-			return fmt.Errorf("cannot use an output format %q and quiet mode at same time", opts.Output)
+			return cli.UserErrorf("cannot use an output format %q and quiet mode at same time", opts.Output)
 		}
 		opts.Output = "quiet"
 	}
 
 	// TODO: Should we implement this rule?
 	// if config.Quiet && len(opts.ClustersName) > 1 {
-	// 	return fmt.Errorf("cannot use quiet mode for multiple clusters, just one cluster is allowed")
+	// 	return cli.UserErrorf("cannot use quiet mode for multiple clusters, just one cluster is allowed")
 	// }
 
 	// DEBUG:
@@ -220,7 +220,7 @@ func getEnvRun(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		if len(klusterList) == 0 || klusterList[0] == nil {
-			return fmt.Errorf("cluster %q not found, to find the cluster name try: kubekit get clusters", opts.ClusterName)
+			return cli.UserErrorf("cluster %q not found, to find the cluster name try: kubekit get clusters", opts.ClusterName)
 		}
 		kubeconfigPath = filepath.Join(filepath.Dir(klusterList[0].Path()), "certificates", "kubeconfig")
 	}
@@ -238,16 +238,16 @@ func getEnvRun(cmd *cobra.Command, args []string) error {
 
 // func getFilesRun(cmd *cobra.Command, args []string) error {
 // 	if len(args) == 0 {
-// 		return fmt.Errorf("requires a cluster name")
+// 		return cli.UserErrorf("requires a cluster name")
 // 	}
 // 	clusterName := args[0]
 // 	if len(clusterName) == 0 {
-// 		return fmt.Errorf("cluster name cannot be empty")
+// 		return cli.UserErrorf("cluster name cannot be empty")
 // 	}
 
 // 	filenames := args[1:]
 // 	if len(filenames) == 0 {
-// 		return fmt.Errorf("requires at least a filename")
+// 		return cli.UserErrorf("requires at least a filename")
 // 	}
 
 // 	output := cmd.Flags().Lookup("output").Value.String()
@@ -256,7 +256,7 @@ func getEnvRun(cmd *cobra.Command, args []string) error {
 // 	pathStr := cmd.Flags().Lookup("path").Value.String()
 // 	paths, err := stringToArray(pathStr)
 // 	if err != nil {
-// 		return fmt.Errorf("failed to parse the list of paths")
+// 		return cli.UserErrorf("failed to parse the list of paths")
 // 	}
 // 	if len(paths) == 0 {
 // 		paths = []string{"/"}
@@ -264,15 +264,15 @@ func getEnvRun(cmd *cobra.Command, args []string) error {
 // 	nodesStr := cmd.Flags().Lookup("nodes").Value.String()
 // 	nodes, err := stringToArray(nodesStr)
 // 	if err != nil {
-// 		return fmt.Errorf("failed to parse the list of nodes")
+// 		return cli.UserErrorf("failed to parse the list of nodes")
 // 	}
 // 	poolsStr := cmd.Flags().Lookup("pools").Value.String()
 // 	pools, err := stringToArray(poolsStr)
 // 	if err != nil {
-// 		return fmt.Errorf("failed to parse the list of pools")
+// 		return cli.UserErrorf("failed to parse the list of pools")
 // 	}
 // 	if len(nodes) != 0 && len(pools) != 0 {
-// 		return fmt.Errorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
+// 		return cli.UserErrorf("'nodes' and 'pools' flags are mutually exclusive, use --nodes or --pools but not both in the same command")
 // 	}
 
 // 	// DEBUG:

--- a/cli/kubekit/login.go
+++ b/cli/kubekit/login.go
@@ -90,14 +90,14 @@ func addLoginCmd() {
 
 func loginClusterRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 cluster name, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 cluster name, received %d. %v", len(args), args)
 	}
 	clusterName := args[0]
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name cannot be empty")
+		return cli.UserErrorf("cluster name cannot be empty")
 	}
 
 	// DEBUG:
@@ -176,20 +176,20 @@ func loginClusterRun(cmd *cobra.Command, args []string) error {
 
 func loginNodeRun(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return fmt.Errorf("requires a node hostname or IP address")
+		return cli.UserErrorf("requires a node hostname or IP address")
 	}
 	if len(args) != 1 {
-		return fmt.Errorf("accepts 1 node, received %d. %v", len(args), args)
+		return cli.UserErrorf("accepts 1 node, received %d. %v", len(args), args)
 	}
 	nodeName := args[0]
 	if len(nodeName) == 0 {
-		return fmt.Errorf("node hostname or IP cannot be empty")
+		return cli.UserErrorf("node hostname or IP cannot be empty")
 	}
 
 	// TODO: Should we remove this and search the node in every cluster?
 	clusterName := cmd.Flags().Lookup("cluster").Value.String()
 	if len(clusterName) == 0 {
-		return fmt.Errorf("cluster name is required")
+		return cli.UserErrorf("cluster name is required")
 	}
 
 	// DEBUG:

--- a/cli/kubekit/token.go
+++ b/cli/kubekit/token.go
@@ -3,6 +3,7 @@ package kubekit
 import (
 	"fmt"
 
+	"github.com/liferaft/kubekit/cli"
 	"github.com/liferaft/kubekit/pkg/aws_iam_authenticator/token"
 	"github.com/spf13/cobra"
 )
@@ -35,7 +36,7 @@ func tokenRun(cmd *cobra.Command, args []string) error {
 	// fmt.Printf("token -i %s -r %s\n", clusterID, roleARN)
 
 	if len(clusterID) == 0 {
-		return fmt.Errorf("requires a cluster name")
+		return cli.UserErrorf("requires a cluster name")
 	}
 
 	cluster, err := loadCluster(clusterID)

--- a/cli/kubekitctl/kubekitctl.go
+++ b/cli/kubekitctl/kubekitctl.go
@@ -1,11 +1,11 @@
 package kubekitctl
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/johandry/log"
+	"github.com/liferaft/kubekit/cli"
 	clientv1 "github.com/liferaft/kubekit/pkg/client/v1"
 	homedir "github.com/mitchellh/go-homedir"
 )
@@ -46,7 +46,7 @@ var config *Config
 
 func (c *Config) init() error {
 	if c.NoGRPC && c.NoHTTP {
-		return fmt.Errorf("no-http and no-grpc cannot be used at same time")
+		return cli.UserErrorf("no-http and no-grpc cannot be used at same time")
 	}
 
 	if c.PortGRPC == "" {

--- a/cli/kubekitctl/root.go
+++ b/cli/kubekitctl/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/johandry/log"
+	"github.com/liferaft/kubekit/cli"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -31,8 +32,11 @@ func Execute() {
 
 	addCommands()
 
-	if err := RootCmd.Execute(); err != nil {
+	if c, err := RootCmd.ExecuteC(); err != nil {
 		fmt.Fprintf(os.Stderr, "\n\x1B[91;1m[ERROR]\x1B[0m %s\n", err)
+		if _, ok := err.(cli.UserError); ok {
+			c.Printf("\n%s\n", c.UsageString())
+		}
 		os.Exit(1)
 	}
 }

--- a/cli/user_error.go
+++ b/cli/user_error.go
@@ -1,0 +1,15 @@
+package cli
+
+import "fmt"
+
+// UserError this is an error caused by a user input, not by the system
+type UserError struct {
+	msg string
+}
+
+func (u UserError) Error() string { return u.msg }
+
+// UserErrorf create an User Error similar to fmt.Errorf()
+func UserErrorf(format string, a ...interface{}) UserError {
+	return UserError{fmt.Sprintf(format, a...)}
+}

--- a/cli/user_error_test.go
+++ b/cli/user_error_test.go
@@ -1,0 +1,27 @@
+package cli
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestUserError(t *testing.T) {
+	errFactory := func() error {
+		return UserErrorf("this is a user error")
+	}
+
+	err := errFactory()
+	if _, ok := err.(UserError); !ok {
+		t.Errorf("UserErrorf() is not returning a User Error")
+	}
+
+	want := "error: this is a user error"
+	if got := fmt.Sprintf("error: %s", err); got != want {
+		t.Errorf("UserError.Error() = %v; want %v", got, want)
+	}
+
+	err2 := fmt.Errorf("this is a system error")
+	if _, ok := err2.(UserError); ok {
+		t.Errorf("Error is considered an UserError")
+	}
+}


### PR DESCRIPTION
<!--
Pull requests are always welcome

Not sure if that typo is worth a pull request? Found a bug and know how to fix
it? Do it! We will appreciate it. Any significant improvement should be
documented as [a GitHub issue](https://github.com/liferaft/kubekit/issues) before
anybody starts working on it.

We are always thrilled to receive pull requests. We do our best to process them
quickly. If your pull request is not accepted on the first try,
don't get discouraged!

** Make sure all your commits include a signature generated with `git commit -s` **
-->

**Community Note**

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Ensure you have added or ran the appropriate tests for this pull request
* If the PR is unfinished, add `[WIP]` prefix to the pull request title and add the `do-not-merge` label.
* Include in the title the category of this pull request. The categories are: `[WIP]`, `[Feature]` or `[Fix]`. If the category is unknown use `[WIP]`, once the PR is ready to be merged replace `[WIP]` for the right category.
* Always assign label(s) to your PR.

**What this PR does / Why we need it:**
This PR is to solve issue #2. After KubeKit fails it prints the error message and the KubeKit usage message. The usage message should be only be printed when the error is related to the user input, not for every error, not for system/KubeKit errors. This feature should be able to have these 2 kinds of errors to print the correct output.

**References:**
* Fixes #2 

**How I did it:**
The CLI has a `UserError` structure that implements `Error`. At the end of the execution of KubeKit, if there is an error and it is a `UserError` the KubeKit usage will be printed after the error message. 
For every future error that is caused by the user input, the error should be created with `cli.UserErrorf()` instead of `fmt.Errorf()`.

**How to verify it:**
Besides the  unit tests, you can run KubeKit with an incorrect input and expect the error message and the KubeKit usage. Executing KubeKit with a non-user error and expect only the error message.

**User Errors:**

```
$ ./kubekit init cluster checking
[Feb 10 14:56:39.048] ERROR kubekit: platform is required

[ERROR] platform is required

Usage:
  kubekit init cluster NAME [flags]
....
```

```
$ ./kubekit init cluster checking -p aws
[Feb 10 14:56:42.683] ERROR kubekit: 'aws' is no longer a supported platform name, use 'ec2' instead

[ERROR] 'aws' is no longer a supported platform name, use 'ec2' instead

Usage:
  kubekit init cluster NAME [flags]

Aliases:
...
```

**KubeKit Error:**
```
$ ./kubekit init cluster checking -p ec2
[Feb 10 14:56:46.050] WARN  kubekit: AWS credentials incomplete or not provided in flags and environment, taking them from local AWS configuration

$ ./kubekit init cluster checking -p ec2
[Feb 10 14:56:48.963] WARN  kubekit: AWS credentials incomplete or not provided in flags and environment, taking them from local AWS configuration
[Feb 10 14:56:48.980] ERROR kubekit: failed to initialize the cluster checking. cluster name "checking" already exists

[ERROR] failed to initialize the cluster checking. cluster name "checking" already exists

$
```

**Description for the changelog:**
- Print the KubeKit usage only when there is an error caused by the user input or misuse of KubeKit.
