### PR TITLE
[Fix] panic when `kubekit describe cluster` is executed

### DIFF
--- a/cli/kubekit/describe.go
+++ b/cli/kubekit/describe.go
@@ -59,10 +59,14 @@ func addDescribeCmd() {
 	describeCmd.Flags().String("format", "", "pretty-print the cluster configuration using a Go template")
 
 	describeCmd.AddCommand(describeClusterCmd)
-	// describe templates NAME[,NAME ...] --output (json|yaml|toml) --pp
+	// describe templates NAME[,NAME ...] --output (json|yaml|toml) --pp --format ...
+	describeClusterCmd.Flags().String("format", "", "pretty-print the cluster configuration using a Go template")
+
 	describeCmd.AddCommand(describeTemplatesCmd)
 	// describe nodes CLUSTER-NAME --output (json|yaml|toml) --pp
+
 	describeCmd.AddCommand(describeNodesCmd)
+	// describe templates NAME[,NAME ...] --output (json|yaml|toml) --pp --cluster NAME
 	describeNodesCmd.Flags().StringP("cluster", "c", "", "cluster name where this node is located")
 }
 


### PR DESCRIPTION
<!--
Pull requests are always welcome

Not sure if that typo is worth a pull request? Found a bug and know how to fix
it? Do it! We will appreciate it. Any significant improvement should be
documented as [a GitHub issue](https://github.com/liferaft/kubekit/issues) before
anybody starts working on it.

We are always thrilled to receive pull requests. We do our best to process them
quickly. If your pull request is not accepted on the first try,
don't get discouraged!

** Make sure all your commits include a signature generated with `git commit -s` **
-->

**Community Note**

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
* Ensure you have added or ran the appropriate tests for this pull request
* If the PR is unfinished, add `[WIP]` prefix to the pull request title and add the `do-not-merge` label.
* Include in the title the category of this pull request. The categories are: `[WIP]`, `[Feature]` or `[Fix]`. If the category is unknown use `[WIP]`, once the PR is ready to be merged replace `[WIP]` for the right category.
* Always assign label(s) to your PR.

**What this PR does / Why we need it:**
Add the flag `--format` to the `describe cluster` command. It was on the `describe` command but was missing in the `describe cluster` command.

**References:**
* Fixes #4 

**How I did it:**
Adding the flag `--format` to `describe cluster` command:
`describeClusterCmd.Flags().String("format", ...)`

**How to verify it:**
Having a cluster named `checking` (or any other name), execute the following commands:
```
kubekit describe cluster checking
kubekit describe cluster checking --format ""
kubekit describe checking
kubekit describe checking --format ""
```

**Description for the changelog:**
- Fix bug causing panic when command `describe cluster` is executed
